### PR TITLE
Fixed memory leak in packData()

### DIFF
--- a/cruncher/Pack.h
+++ b/cruncher/Pack.h
@@ -99,6 +99,7 @@ void packData(unsigned char *data, int data_length, int zero_padding, PackParams
 		measurer->setNumberContexts(LZEncoder::NUMBER_CONTEXT_OFFSET, LZEncoder::NUM_NUMBER_CONTEXTS, data_length);
 		finder.reset();
 		result = parser.parse(LZEncoder(measurer), progress);
+		delete measurer;
 
 		// Encode result using adaptive range coding
 		vector<unsigned> dummy_result;


### PR DESCRIPTION
This fixes a memory leak in packData(). It was detected by Microsoft's debug runtime.
Cheers
Thomas